### PR TITLE
Pass "params" from episerver onto react component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ export interface EditorProps {
     onChange: (value: any) => void;
     readOnly?: boolean;
     value: any;
+    params: any;
 }
 
 export const asEditorWidget = (WrappedComponent: ComponentType<EditorProps>): unknown => {
@@ -36,6 +37,7 @@ export const asEditorWidget = (WrappedComponent: ComponentType<EditorProps>): un
                     onChange={this.handleChange.bind(this)}
                     readOnly={this.readOnly}
                     value={value}
+                    params={this.params}
                 />,
                 this.domNode
             );


### PR DESCRIPTION
A Dojo widget for Episerver receives a "params" object. It's one way to pass custom data from Episerver to the widget.

Here's an example from an existing (non-React) widget we have. You can see some attributes like the `label`, `isLanguageSpecific`, but also an array called `icons` that I've passed to the widget in `SetEditorConfiguration`.

![image](https://user-images.githubusercontent.com/5163790/94481966-df8c2700-01d8-11eb-988b-d4921a888d62.png)

I'm not entirely sure about how to type `params` (eg. what parts of it are optional), so I've left it as "any" for now so I can create the typing I will actually use myself.